### PR TITLE
Added record for tv.neo, a live streaming server

### DIFF
--- a/dns/neonetwork
+++ b/dns/neonetwork
@@ -35,6 +35,8 @@ acme                      IN    AAAA     fd10:127:53:223::1
 edwardp                   IN    A        10.127.8.130
 edwardp                   IN    AAAA     fd10:127:2f2f::
 
+tv                        IN    A        10.127.15.58
+
 ; DELEGATED ZONES
 jerry                     IN    NS       ns1.jerry
 jerry                     IN    NS       ns2.jerry


### PR DESCRIPTION
I have a very nice TV streaming server on NeoNetwork :)

After registration, the following links can be used to watch TV channels:

http://tv.neo:8080/channels/tv-31/playlist.m3u8
http://tv.neo:8080/channels/tv-31/mpeg.2ts
http://tv.neo:8080/channels/tv-99/playlist.m3u8
http://tv.neo:8080/channels/tv-99/mpeg.2ts
http://tv.neo:8080/channels/tw-501/playlist.m3u8
http://tv.neo:8080/channels/tw-501/mpeg.2ts

etc.

For a full list, it is available upon request.