### PR TITLE
change the gpg public key

### DIFF
--- a/entity/Anillc.toml
+++ b/entity/Anillc.toml
@@ -5,4 +5,4 @@ email = "noc@anillc.cn"
 github = "Anillc"
 
 [persona]
-pgp = "DCD75832819A6CAB61C8F7D337F54FEE22679910"
+pgp = "BB47FA42A55975F74AE19EF8918F98A096F9533C"


### PR DESCRIPTION
由于之前的 GPG 密钥已经 revoke 并删掉，但是在 NeoNetwork 这边却忘记更改，希望可以改一下。  
这是在 DN42 那边更改公钥的 pr ，使用了原来的 key 签名：<https://git.dn42.dev/dn42/registry/pulls/879/files>