### PR TITLE
AS4201270080: vlab DN42 /26+/56, hanako.neo DNS glue update

### DIFF
--- a/dns/dnssec/hanako.neo.keys
+++ b/dns/dnssec/hanako.neo.keys
@@ -1,0 +1,4 @@
+; KSK owner entity/Hanako
+hanako.neo. 3600 IN DNSKEY 257 3 13 Ce5f5qBqBQG4LhNl90pVohBmT68mVxf/3lTo+RdMK7D9e0lu/L3gHIg8 n6w1aqcWmKr9V4SnYvdtIqK1GIaNzA==
+; ZSK owner entity/Hanako
+hanako.neo. 3600 IN DNSKEY 256 3 13 /+CBWePThFQDMHS1rWNA9uNqIMQVQBogXHUU8MVCxmQarfvA2WB7XYpL QZwmUoe6EPbwot1EUtS6xafFDoF8rA==

--- a/dns/neonetwork
+++ b/dns/neonetwork
@@ -187,8 +187,9 @@ ns0.hmn                   IN    AAAA     fd10:127:45:233::1
 hjt                       IN    NS       ns0.hmn
 
 hanako                    IN    NS       ns.hanako
-ns.hanako                 IN    A        10.127.80.80
-ns.hanako                 IN    AAAA     fd10:127:80:aa00::1
+hanako                    IN    DS       12417 13 2 E38157E8EEEF9DBE0A68B5DABF6993F3B28859512F7AA6CB43935B69305A4132
+ns.hanako                 IN    A        10.127.80.2
+ns.hanako                 IN    AAAA     fd10:127:80:1000::53
 
 saru                      IN    NS       lb.ns.saru
 saru                      IN    DS       42159 13 2 D8AF3E06E8D4E21C1FFA85CBE3DEC6E7DA06095283109D4289C4BBDF23283E1B

--- a/entity/Hanako.toml
+++ b/entity/Hanako.toml
@@ -6,4 +6,4 @@ telegram = "koizumi_k"
 github = "hanakokoizumi"
 
 [persona]
-pgp = "01852E0786EA31525651925075AEC845FF3BD945"
+pgp = "E5C7E5AAF7AE441AA1B4719B432DB45123D1C601"

--- a/route/AS4201270080.toml
+++ b/route/AS4201270080.toml
@@ -5,3 +5,37 @@ name = "Hanako-Network-Neo-1-v4"
 ["fd10:127:80::/48"]
 type = "subnet"
 name = "Hanako-Network-Neo-1-v6"
+
+["10.127.80.0/26"]
+type = "subnet"
+name = "vlab-dn42-v4"
+description = "vlab DN42 router + services"
+supernet = "10.127.80.0/24"
+max-len = 29
+
+["fd10:127:80:1000::/56"]
+type = "subnet"
+name = "vlab-dn42-v6"
+description = "vlab DN42 router + services"
+supernet = "fd10:127:80::/48"
+max-len = 64
+
+["10.127.80.1/32"]
+type = "loopback"
+name = "vlab-dn42-gw-v4"
+supernet = "10.127.80.0/26"
+
+["10.127.80.2/32"]
+type = "loopback"
+name = "ns-hanako-v4"
+supernet = "10.127.80.0/26"
+
+["fd10:127:80:1000::1/128"]
+type = "loopback"
+name = "vlab-dn42-gw-v6"
+supernet = "fd10:127:80:1000::/56"
+
+["fd10:127:80:1000::53/128"]
+type = "loopback"
+name = "ns-hanako-v6"
+supernet = "fd10:127:80:1000::/56"


### PR DESCRIPTION
## Summary
- Add vlab-dn42 IPv4 /26 and IPv6 /56 subnets under AS4201270080
- Add loopback entries for router and ns.hanako
- Update hanako.neo glue records to 10.127.80.2 / fd10:127:80:1000::53
- Add hanako.neo DNSSEC keys and DS record in parent neo zone
- Update Hanako entity PGP fingerprint (key rotation)

## Test plan
- [ ] NeoNetwork CI (test-your-pr) passes
- [ ] ROA/roa.neocloud.tw reflects new prefixes after merge